### PR TITLE
Fix 'testing eqality to None' python issues

### DIFF
--- a/python_modules/import_export/sciaXML/project.py
+++ b/python_modules/import_export/sciaXML/project.py
@@ -135,7 +135,7 @@ class Project:
 
       item= ObjectItem()
       item.setV(peca.getId())
-      if(objectOrigem.getP3() != None):
+      if(objectOrigem.getP3() is not None):
         valor= objectOrigem.getP3().getN().substring(0, objectOrigem.getP3().getN().indexOf("-")-1)
         item.setN(valor)
 

--- a/python_modules/materials/concrete_base.py
+++ b/python_modules/materials/concrete_base.py
@@ -695,9 +695,9 @@ class Concrete(matWDKD.MaterialWithDKDiagrams):
         return 2*self.fmaxK()/self.epsilon0()
         
     def plotDesignStressStrainDiagram(self,preprocessor,path=''):
-        if self.materialDiagramD== None:
+        if self.materialDiagramD is None:
           self.defDiagD(preprocessor)
-        if self.tensionStiffparam==None:
+        if self.tensionStiffparam is None:
             retval= graph_material.UniaxialMaterialDiagramGraphic(epsMin=self.epsilonU(),epsMax=0,title=self.materialName + ' design stress-strain diagram')
         else:
             retval= graph_material.UniaxialMaterialDiagramGraphic(epsMin=self.epsilonU(),epsMax=20*self.fctd()/self.E0(),title=self.materialName + ' design stress-strain diagram')
@@ -1045,7 +1045,7 @@ class ReinforcingSteel(matWDKD.MaterialWithDKDiagrams):
 
     def plotDesignStressStrainDiagram(self,preprocessor,path=''):
         '''Draws the steel design diagram.'''
-        if self.materialDiagramD== None:
+        if self.materialDiagramD is None:
             self.defDiagD(preprocessor)
         retval= mg.UniaxialMaterialDiagramGraphic(-0.016,0.016, self.materialName + ' design stress-strain diagram')
         retval.setupGraphic(plt,self.materialDiagramD)

--- a/python_modules/materials/ehe/EHE_limit_state_checking.py
+++ b/python_modules/materials/ehe/EHE_limit_state_checking.py
@@ -1377,7 +1377,7 @@ class CrackControl(lscb.CrackControlBaseParameters):
                                        steel material.
          :param fctm: average tensile strength of the concrete.
         '''
-        if(self.rcSets == None):
+        if(self.rcSets is None):
             self.rcSets= fiber_sets.fiberSectionSetupRC3Sets(scc,concreteMatTag,self.concreteFibersSetName,reinfSteelMaterialTag,self.rebarFibersSetName)
         concrFibers= self.rcSets.concrFibers.fSet
         reinfFibers= self.rcSets.reinfFibers.fSet

--- a/python_modules/materials/sections/fiber_section/plot_fiber_section.py
+++ b/python_modules/materials/sections/fiber_section/plot_fiber_section.py
@@ -101,41 +101,41 @@ class fibSectFeaturesToplot(object):
                 R= b.diameter/2.0
                 ax2d.add_artist(plt.Circle((cent[0],cent[1]),R,color='black'))
         #Neutral axis 
-        if self.colorNeutralAxis != None:
+        if self.colorNeutralAxis is not None:
             (y,z)=data_axis_to_pyplot(self.fiberSection.getNeutralAxis(),self.contour)
             ax2d.plot(y,z,self.colorNeutralAxis,label='Neutral axis')
         #Bending plane
-        if self.colorBendingPlane != None:
+        if self.colorBendingPlane is not None:
             (y,z)=data_axis_to_pyplot(self.fiberSection.getBendingPlaneTrace(),self.contour)
             ax2d.plot(y,z,self.colorBendingPlane,label='Bending plane')
         #Compression plane
-        if self.colorCompressionPlane != None:
+        if self.colorCompressionPlane is not None:
             (y,z)=data_axis_to_pyplot(self.fiberSection.getCompressedPlaneTrace(),self.contour)
             ax2d.plot(y,z,self.colorCompressionPlane,label='Compression plane')
         #Tension plane
-        if self.colorTensionPlane != None:
+        if self.colorTensionPlane is not None:
             (y,z)=data_axis_to_pyplot(self.fiberSection.getTensionedPlaneTrace(),self.contour)
             ax2d.plot(y,z,self.colorTensionPlane,label='Tension plane')
         #Internal forces axis
-        if self.colorIntForcAxis != None:
+        if self.colorIntForcAxis is not None:
             (y,z)=data_axis_to_pyplot(self.fiberSection.getInternalForcesAxes(),self.contour)
             ax2d.plot(y,z,self.colorIntForcAxis ,label='Internal forces axis')
         #Lever arm
-        if self.colorLeverArm != None:
+        if self.colorLeverArm is not None:
             (y,z)= data_xcsegment_to_pyplot(self.fiberSection.getLeverArmSegment())
             ax2d.plot(y,z,self.colorLeverArm,label='Lever arm')
         #Effective depth
-        if self.colorEffDepth != None:
+        if self.colorEffDepth is not None:
             (y,z)= data_xcsegment_to_pyplot(self.fiberSection.getEffectiveDepthSegment())
             ax2d.plot(y,z,self.colorEffDepth,label='Effective depth')
         #Limit of concrete effective area
-        if self.colorEffConcrArea != None:
+        if self.colorEffConcrArea is not None:
             if self.MaxEffHeight==None:
                 lmsg.error("I can't plot the limit of the effective concrete area, a value to MaxEffHeight must be provided \n")
             else:
                 (y,z)=data_axis_to_pyplot(self.fiberSection.getEffectiveConcreteAreaLimitLine(self.MaxEffHeight),self.contour)
                 ax2d.plot(y,z,self.colorEffConcrArea,label='Limit of effective concrete area')
-        if self.colorGrossEffConcrAreaContours != None:
+        if self.colorGrossEffConcrAreaContours is not None:
             if self.MaxEffHeight==None:
                 lmsg.error("I can't plot the contours of the gross effective concrete area, a value to MaxEffHeight must be provided \n")
             else:

--- a/python_modules/misc/sqlite_utils/ansys_to_intforc_beam.py
+++ b/python_modules/misc/sqlite_utils/ansys_to_intforc_beam.py
@@ -55,7 +55,7 @@ def ansysCreaElem(nmbDBase,nmbTablaElem, sectionName):
     cur.execute("select * from " + nmbTablaElem)
     while True:
         row= cur.fetchone()
-        if row == None:
+        if row is None:
             break
         else:
             nuevoZeroLengthSeccFibras(sectionName,i,row("ELEM"))

--- a/python_modules/model/mesh/finit_el_model.py
+++ b/python_modules/model/mesh/finit_el_model.py
@@ -116,7 +116,7 @@ class LinSetToMesh(RawLineSetToMesh):
     def __init__(self,linSet,matSect,elemSize,vDirLAxZ, elemType='ElasticBeam3d',dimElemSpace=3,coordTransfType='linear'):
         self.vDirLAxZ= vDirLAxZ
         cTrf= None
-        if(coordTransfType!= None):
+        if(coordTransfType is not None):
           trfName= linSet.name+'trYGlobal'
           cTrf= getDefaultCoordinateTransformation(linSet.owner,trfName,coordTransfType,self.vDirLAxZ)
         super(LinSetToMesh,self).__init__(linSet,matSect,elemSize,cTrf,elemType,dimElemSpace)

--- a/python_modules/postprocess/phantom_model.py
+++ b/python_modules/postprocess/phantom_model.py
@@ -134,7 +134,7 @@ class PhantomModel(object):
                 for i in range(0,sz):
                     sectionName= elementSectionNames[i]
                     diagInt= None
-                    if(mapInteractionDiagrams != None):
+                    if(mapInteractionDiagrams is not None):
                         diagInt= mapInteractionDiagrams[sectionName]
           #         print('tagElem =',tagElem,' sectionName=',sectionName,' elSecDef=',elementSectionDefinitions[i],' sectIndex=', i+1,' diagInt=', diagInt)
                     phantomElem= self.createPhantomElement(tagElem,sectionName,elementSectionDefinitions[i],i+1,diagInt, outputCfg.controller.fakeSection)

--- a/python_modules/solution/predefined_solutions.py
+++ b/python_modules/solution/predefined_solutions.py
@@ -1307,7 +1307,7 @@ class BucklingAnalysisEigenPart(SolutionProcedure):
         '''        
         super(BucklingAnalysisEigenPart,self).__init__(name, constraintHandlerType= None, printFlag= printFlag, numberingMethod= None, soeType= soeType, solverType= solverType, shift= shift)
         modelWrapper= staticAnalysisPart.getModelWrapper
-        if(modelWrapper!= None):
+        if(modelWrapper is not None):
             self.modelWrapper= modelWrapper
         else:
             className= type(self).__name__


### PR DESCRIPTION
"When you compare an object to None, use is rather than ==. None is a singleton object, comparing using == invokes the __eq__ method on the object in question, which may be slower than identity comparison. Comparing to None using the is operator is also easier for other programmers to read."