### PR TITLE
Installation: Ubuntu 24.04 improvements

### DIFF
--- a/install/install.scripts.linux.md
+++ b/install/install.scripts.linux.md
@@ -4,6 +4,24 @@ XC installation scripts for Linux operating system
 ## Dependencies
 Depending on the various distribution out there we gone provide scripts to install the needed dependency packages needed to compile XC.
 
+### Note: Windows Subsystem for Linux
+If you are running in Windows Subsystem for Linux, launch your WSL terminal and install python3 and make sure it is the default on your system. Then close all your terminals and launch it again to continue the installation process.
+
+``` console
+sudo apt-get install -y python3 python-is-python3
+#
+```
+
+#### Ubuntu Noble (Ubuntu 24.04)
+
+- packages_install_ubuntu_24.04.sh
+- https://github.com/xcfem/xc/blob/master/install/packages_install_ubuntu_24.04.sh
+```console
+wget https://raw.githubusercontent.com/xcfem/xc/master/install/packages_install_ubuntu_24.04.sh
+sudo bash packages_install_ubuntu_24.04.sh
+#
+```
+
 #### Ubuntu Focal Fossa (Ubuntu 20)
 
 - packages_install_ubuntu_focal_fossa.sh

--- a/install/packages_install_ubuntu_24.04.sh
+++ b/install/packages_install_ubuntu_24.04.sh
@@ -22,6 +22,25 @@ if [ "$1" != "DoNotAsk" ]; then
     fi
 fi
 
+sudo apt-get update -y
+
+# add universe repository so packages like gtk3 can be found
+sudo install software-properties-common
+sudo add-apt-repository universe
+sudo apt-get update -y
+
+build_essential="\
+    build-essential  \
+    zlib1g-dev       \
+    libncurses5-dev  \
+    libgdbm-dev      \
+    libnss3-dev      \
+    libssl-dev       \
+    libreadline-dev  \
+    libffi-dev       \
+    wget"
+sudo apt-get install -y $build_essential
+
 # packages installed by package manager apt-get
 # tested on Ubuntu 18.04 Bionic Beaver
 packages_build="\
@@ -42,11 +61,8 @@ packages_lib="\
     libf2c2-dev                 \
     libglib2.0-dev              \
     libgmp3-dev                 \
-    libgtk2.0-dev               \
-    libgtkgl2.0-dev             \
-    libgtkglextmm-x11-1.2-dev   \
-    libgtkglext1-dev            \
-    libgtkmm-2.4-dev            \
+    libgtk-3-dev                \
+    libgtkmm-3.0-dev            \
     libgts-bin                  \
     libgts-dev                  \
     liblapack-dev               \
@@ -65,9 +81,9 @@ packages_lib="\
 sudo apt-get install -y $packages_lib
 
 packages_dev="\
-    python3-dev          \
-    cimg-dev  \
-    petsc-dev \
+    python3-dev \
+    cimg-dev    \
+    petsc-dev   \
     tcl-dev"
 sudo apt-get install -y $packages_dev
 


### PR DESCRIPTION
Ubuntu 24.04 refuses to install libgtk2.0-dev and other deprecated gtk packages. This pull request updates gtk to 3.0 and add installation documentation for this version of Ubuntu.

Note: gtk-dev and gmsh needs the ability to fetch from universe repostory, so this was also added on the installation script.